### PR TITLE
Remove electron-prebuilt dependency from lib/server.js

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -2,7 +2,6 @@
 
 var EventEmitter = require('events').EventEmitter;
 var proc = require('child_process');
-var electron = require('electron-prebuilt');
 var webSocket = require('ws');
 var _ = require('lodash');
 var SocketWrapper = require('./socketWrapper');


### PR DESCRIPTION
This is causing an error since I'm not using `electron-prebuilt` in my project, and this require is useless.