### PR TITLE
upgrade ws dependency to v0.8.0, as it is compatible with io.js 3 + electron v0.31.x + electron-rebuild + NaN2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "lodash": "^3.10.1",
-    "ws": "^0.7.2"
+    "ws": "^0.8.0"
   },
   "devDependencies": {
     "electron-prebuilt": "^0.30.1",


### PR DESCRIPTION
Fixes #6  This will enable electron-rebuild to build native modules of the dependencies.