### PR TITLE
Fixed typo, added logClientMsgs option

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -45,7 +45,7 @@ ProcessManager.prototype.start = function (args, cb) {
 
   this.wss = new webSocket.Server({ port: this.opt.port}, function () {
     this.spawn(args, this.opt.spawnOpt);
-    this.log('created and liseten to ' + this.opt.port);
+    this.log('created and listening on port ' + this.opt.port);
     if(typeof cb === 'function') {
       cb();
     }
@@ -53,7 +53,9 @@ ProcessManager.prototype.start = function (args, cb) {
   this.wss.on('connection', function connection(ws) {
     var wrapper = new SocketWrapper( ws); 
     wrapper.on('message', function (message) {
-      this.log('receive message from client(window_id: ' + wrapper.id + ') '+  message);
+      if (this.opt.logClientMsgs) {
+        this.log('receive message from client(window_id: ' + wrapper.id + ') '+  message);
+      }
       var obj = JSON.parse(message);
       if(obj.type && typeof obj.type === 'string') {
         this.emit(obj.type, obj.data, wrapper);
@@ -158,7 +160,8 @@ module.exports = {
       electron: electron,
       path: process.cwd(),
       port: 30080,
-      spawnOpt: {stdio: 'inherit'}
+      spawnOpt: {stdio: 'inherit'},
+      logClientMsgs: (options && options.logClientMsgs) || false
     }, options || {});
     return new ProcessManager().init(opt);
   }


### PR DESCRIPTION
The logClientMsgs option gives the user the option whether or not to log messages received from the client (defaults to false).