### PR TITLE
Fix issue #11

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -149,7 +149,7 @@ module.exports = {
       try {
         electron = require('electron-prebuilt');
       } catch (e) {
-        if(e.code === 'MODULE_NOT_FOUND') {
+        if(e.code === 'MODULE_NOT_FOUND' || e.code === 'ENOENT') {
           electron = 'electron';
         }
       }


### PR DESCRIPTION
`e.code` was `ENOENT` when `electron-prebuilt` was not installed locally. Since the check failed, the `electron` option was `undefined` and was passed to `.spawn`, which resulted in a `Bad argument` error.