### PR TITLE
Added stopOnClose option

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -62,6 +62,9 @@ ProcessManager.prototype.start = function (args, cb) {
     wrapper.on('close', function () {
       this.log('client (window_id: ' + wrapper.id + ') closed.');
       SocketWrapper.delete(wrapper.id);
+      if (this.opt.stopOnClose) {
+        this.stop();
+      }
     }.bind(this));
 
   }.bind(this));
@@ -155,6 +158,7 @@ module.exports = {
       }
     }
     var opt = _.merge({
+      stopOnClose: false,
       electron: electron,
       path: process.cwd(),
       port: 30080,

--- a/lib/server.js
+++ b/lib/server.js
@@ -12,6 +12,7 @@ var ProcessManager = function () {
   this.restart = this.restart.bind(this);
   this.reload = this.reload.bind(this);
   this.stop = this.stop.bind(this);
+  this.running = false;
 };
 ProcessManager.prototype = new EventEmitter();
 ProcessManager.prototype.init = function (opt) {
@@ -69,6 +70,7 @@ ProcessManager.prototype.start = function (args, cb) {
 
   }.bind(this));
   this.registerHandler();
+  this.running = true;
 };
 
 ProcessManager.prototype.broadcast = function (type, data) {
@@ -123,6 +125,7 @@ ProcessManager.prototype.stop = function (cb) {
   if(typeof cb === 'function') {
     cb();
   }
+  this.running = false;
 };
 
 ProcessManager.prototype.reload = function (ids) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -12,7 +12,6 @@ var ProcessManager = function () {
   this.restart = this.restart.bind(this);
   this.reload = this.reload.bind(this);
   this.stop = this.stop.bind(this);
-  this.running = false;
 };
 ProcessManager.prototype = new EventEmitter();
 ProcessManager.prototype.init = function (opt) {
@@ -70,7 +69,6 @@ ProcessManager.prototype.start = function (args, cb) {
 
   }.bind(this));
   this.registerHandler();
-  this.running = true;
 };
 
 ProcessManager.prototype.broadcast = function (type, data) {
@@ -125,7 +123,6 @@ ProcessManager.prototype.stop = function (cb) {
   if(typeof cb === 'function') {
     cb();
   }
-  this.running = false;
 };
 
 ProcessManager.prototype.reload = function (ids) {


### PR DESCRIPTION
Added stopOnClose option which will stop the server after the last window of the electron application is closed. Defaults to false, so current behavior is not changed by this. This way, it is not necessary to ctrl+c after the gulp task.
Also this shouldn't be a problem with multiple windows, as it is handled only after last window is closed. Better solution might be to add callback to start, but that would mess with the functions signature.