### PR TITLE
Updated packages and switched out child-process with win-spawn

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var EventEmitter = require('events').EventEmitter;
-var proc = require('child_process');
+var spawn = require('win-spawn');
 var webSocket = require('ws');
 var _ = require('lodash');
 var SocketWrapper = require('./socketWrapper');
@@ -25,7 +25,7 @@ ProcessManager.prototype.log = function (msg) {
 };
 
 ProcessManager.prototype.spawn = function (args, spawnOpt) {
-  this.electronProc = proc.spawn(this.opt.electron, [this.opt.path].concat(args), spawnOpt);
+  this.electronProc = spawn(this.opt.electron, [this.opt.path].concat(args), spawnOpt);
 };
 
 ProcessManager.prototype.start = function (args, cb) {

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
   "license": "MIT",
   "dependencies": {
     "lodash": "^3.10.1",
-    "ws": "^0.8.0"
+    "win-spawn": "^2.0.0",
+    "ws": "^1.0.1"
   },
   "devDependencies": {
-    "electron-prebuilt": "^0.30.1",
+    "electron-prebuilt": "^0.36.3",
     "gulp": "^3.9.0",
     "gulp-mocha": "^2.1.3"
   }


### PR DESCRIPTION
child-process does not work with windows. win-spawn augments spawn with windows code (so should work everywhere).
https://www.npmjs.com/package/win-spawn
>> Spawn for node.js but in a way that works regardless of which OS you're using. 
>> Since all modification is wrapped in if (os === 'Windows_NT') it can be safely used on non-windows systems and will not break anything.

Also, packages were using old electron (0.30.1) now using 0.36.3