### PR TITLE
trying to gently close app

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -130,7 +130,7 @@ ProcessManager.prototype.restart = function (args, cb) {
 ProcessManager.prototype.killProcess = function (cb) {
   if(this.electronProc) {
     this.info('killing electron process tree: ' + this.electronProc.pid);
-    kill(this.electronProc.pid, 'SIGKILL', cb);
+    kill(this.electronProc.pid, 'SIGTERM', cb);
   }
 };
 


### PR DESCRIPTION
It s best to try and close the app gently so that it can handles what's necessary on close.
For example my app is connecting to a ble device.
With sigkill the connection was not closed correctly.