### PR TITLE
fix: adapt to electron 1.0.0

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -7,7 +7,7 @@ var util = require('./util');
 
 var getBrowserWindow = function () {
   if(process.type === 'renderer') {
-    return require('remote').getCurrentWindow();
+    return require('electron').remote.getCurrentWindow();
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-connect",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "description": "Livereload tools for Electron development",
   "main": "index.js",
   "scripts": {
@@ -26,7 +26,7 @@
     "ws": "^1.1.0"
   },
   "devDependencies": {
-    "electron-prebuilt": "^0.37.7",
+    "electron-prebuilt": "^1.0.0",
     "gulp": "^3.9.1",
     "gulp-mocha": "^2.2.0"
   }


### PR DESCRIPTION
in electron v1.0.0, there is no `require('remote')` anymore