### PR TITLE
fix issue #40

### DIFF
--- a/example/browser-client-create/simple/app.js
+++ b/example/browser-client-create/simple/app.js
@@ -1,0 +1,38 @@
+const electron = require('electron');
+const {app} = electron;
+const {BrowserWindow} = electron;
+const {client} = require('../../../');
+
+let mainWindow;
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+function createWindow() {
+  console.log('Hello, browser process');
+  mainWindow = new BrowserWindow({
+    width: 800,
+    height: 300
+  });
+
+  mainWindow.loadURL(`file://${__dirname}/index.html`);
+
+  mainWindow.webContents.openDevTools();
+
+  mainWindow.on('closed', () => {
+    mainWindow = null;
+  });
+  client.create(mainWindow);
+}
+
+app.on('activate', () => {
+  if (mainWindow === null) {
+    createWindow();
+  }
+});
+
+app.on('ready', createWindow);
+

--- a/example/browser-client-create/simple/gulpfile.js
+++ b/example/browser-client-create/simple/gulpfile.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var gulp = require('gulp');
+var electron = require('../../../').server.create();
+
+gulp.task('serve', function () {
+  // Start browser process
+  electron.start();
+
+  // Restart browser process
+  gulp.watch('app.js', ['reload:browser']);
+
+  // Reload renderer process
+  gulp.watch(['index.js', 'index.html'], ['reload:renderer']);
+});
+
+gulp.task('reload:browser', function (done) {
+  // Restart main process
+  electron.restart();
+  done();
+});
+
+gulp.task('reload:renderer', function (done) {
+  // Reload renderer process
+  electron.reload();
+  done();
+});
+
+gulp.task('default', ['serve']);
+

--- a/example/browser-client-create/simple/index.html
+++ b/example/browser-client-create/simple/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Simple example app</title>
+</head>
+<body>
+<h1>Hello, Electron</h1>
+<script src="index.js"></script>
+</body>
+</html>

--- a/example/browser-client-create/simple/index.js
+++ b/example/browser-client-create/simple/index.js
@@ -1,0 +1,4 @@
+'use strict';
+
+console.log('Hello, renderer window!');
+console.log('electron version: ' + process.versions.electron);

--- a/example/browser-client-create/simple/package.json
+++ b/example/browser-client-create/simple/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "electron-connect-simple-example",
+  "version": "0.0.1",
+  "main": "./app.js",
+  "scripts": {
+    "start": "gulp serve"
+  }
+}

--- a/lib/client.js
+++ b/lib/client.js
@@ -83,12 +83,15 @@ Client.prototype.registerWindow = function (browserWindow) {
       this.sendMessage('changeBounds', {bounds: browserWindow.getBounds()});
     }.bind(this));
   }.bind(this));
-  if (typeof window === 'object') {
-    window.addEventListener('beforeunload', function () {
-      if(this.opt.sendBounds) {
-        browserWindow.removeAllListeners('move').removeAllListeners('resize');
-      }
-      this.close();
+  if (process.type == 'renderer') {
+    if (typeof window === 'object') {
+      window.addEventListener('beforeunload', function () {
+        this.close(browserWindow);
+      }.bind(this));
+    }
+  } else {
+    browserWindow.on('closed', function() {
+      this.close(browserWindow);
     }.bind(this));
   }
   this.sendMessage('initBounds', {bounds: browserWindow.getBounds()});
@@ -115,7 +118,10 @@ Client.prototype.registerHandler = function (browserWindow) {
 
 };
 
-Client.prototype.close = function () {
+Client.prototype.close = function (browserWindow) {
+  if(this.opt.sendBounds) {
+    browserWindow.removeAllListeners('move').removeAllListeners('resize');
+  }
   this.socket.terminate();
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-connect",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Livereload tools for Electron development",
   "main": "index.js",
   "scripts": {
@@ -19,15 +19,15 @@
   },
   "license": "MIT",
   "dependencies": {
-    "cross-spawn": "^3.0.1",
-    "lodash": "^4.11.1",
-    "tree-kill": "^1.0.0",
+    "cross-spawn": "^4.0.0",
+    "lodash": "^4.13.1",
+    "tree-kill": "^1.1.0",
     "ws": "^1.1.0"
   },
   "devDependencies": {
-    "electron-prebuilt": "^1.0.0",
+    "electron-prebuilt": "^1.2.1",
     "gulp": "^3.9.1",
     "gulp-mocha": "^2.2.0",
-    "spectron": "^3.0.0"
+    "spectron": "^3.2.2"
   }
 }


### PR DESCRIPTION
Fixes #40. window's ``beforeunload`` event is not relevant to browser process.

Now, in case of browser process, an event handler for ``closed`` event is registered to terminate the socket connection. ``beforeunload`` event handler is retained in case of renderer process.