### PR TITLE
add multi-level verbosity to the logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If you want details, see [example/simple](example/simple).
  * `path` String. A path to your `package.json` file (default: `process.cwd()`).
  * `port` Number. WebSocket server port (default: `30080`).
  * `spawnOpt` Object. Options for [spawn](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).
- * `verbose` Number. The granularity of the electron-connect logging in your prompt. `0` - warning only, `1` - warning and info only, `2` - all logs (default: `1`).
+ * `logLevel` Number. The granularity of the electron-connect logging in your prompt. `0` - warning only, `1` - warning and info only, `2` - all logs (default: `1`).
  * `stopOnClose` Boolean. If set, closing last remaining window stops the electron application.
 
 Returns a new `ProcessManager` object.
@@ -167,7 +167,7 @@ Broadcasts an event to all clients.
 * `options` Object
  * `port` Number. WebSocket server port (default: `30080`) that client should connect to.
  * `sendBounds` Boolean
-  * `verbose` Number. `0` - warning only, `1` - warning and info only, `2` - all logs (default: `1`).
+ * `logLevel` Number. See [server.create([options]).logLevel](#servercreateoptions).
 * `callback` Function
 
 Creates a new `Client` object associated with `browserWindow` and connects to `ProcessManager`.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If you want details, see [example/simple](example/simple).
  * `path` String. A path to your `package.json` file (default: `process.cwd()`).
  * `port` Number. WebSocket server port (default: `30080`).
  * `spawnOpt` Object. Options for [spawn](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).
- * `verbose` Boolean. If set, show all electron-connect log in your prompt (default: `false`).
+ * `verbose` Number. The granularity of the electron-connect logging in your prompt. `0` - warning only, `1` - warning and info only, `2` - all logs (default: `1`).
  * `stopOnClose` Boolean. If set, closing last remaining window stops the electron application.
 
 Returns a new `ProcessManager` object.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Broadcasts an event to all clients.
 * `options` Object
  * `port` Number. WebSocket server port (default: `30080`) that client should connect to.
  * `sendBounds` Boolean
- * `verbose` Boolean
+  * `verbose` Number. `0` - warning only, `1` - warning and info only, `2` - all logs (default: `1`).
 * `callback` Function
 
 Creates a new `Client` object associated with `browserWindow` and connects to `ProcessManager`.

--- a/lib/client.js
+++ b/lib/client.js
@@ -15,7 +15,7 @@ var Client = function () {};
 var defaultOpt = {
   port: 30080,
   sendBounds: true,
-  verbose: 1
+  logLevel: util.LOG_LEVEL_INFO,
 };
 Client.prototype = new EventEmitter();
 
@@ -24,11 +24,11 @@ Client.prototype.warn = function (msg) {
 };
 
 Client.prototype.info = function (msg) {
-  if(this.opt.verbose >= 1) console.log('[' + new Date().toISOString() + '] [electron-connect] [client: ' + this.id + '] ' + msg);
+  if(this.opt.logLevel >= util.LOG_LEVEL_INFO) console.log('[' + new Date().toISOString() + '] [electron-connect] [client: ' + this.id + '] ' + msg);
 };
 
 Client.prototype.verbose = function (msg) {
-  if(this.opt.verbose === 2) console.log('[' + new Date().toISOString() + '] [electron-connect] [client: ' + this.id + '] ' + msg);
+  if(this.opt.logLevel >= util.LOG_LEVEL_VERBOSE) console.log('[' + new Date().toISOString() + '] [electron-connect] [client: ' + this.id + '] ' + msg);
 };
 
 Client.prototype.join = function (browserWindow, options, cb) {
@@ -51,12 +51,14 @@ Client.prototype.join = function (browserWindow, options, cb) {
     }
     browserWindow = getBrowserWindow();
   }
+
   // handle old boolean verbose values
   if (this.opt.verbose === true) {
-    this.opt.verbose = 2;
+    this.opt.verbose = util.LOG_LEVEL_VERBOSE;
   } else if (this.opt.verbose === false) {
-    this.opt.verbose = 1;
+    this.opt.verbose = util.LOG_LEVEL_INFO;
   }
+  
   var id = browserWindow ? browserWindow.id : '_no_browser';
   this.id = id;
   this.socket = new WebSocket('ws://localhost:' + this.opt.port + '/' + '?window_id=' + id);

--- a/lib/client.js
+++ b/lib/client.js
@@ -54,9 +54,9 @@ Client.prototype.join = function (browserWindow, options, cb) {
 
   // handle old boolean verbose values
   if (this.opt.verbose === true) {
-    this.opt.verbose = util.LOG_LEVEL_VERBOSE;
+    this.opt.logLevel = util.LOG_LEVEL_VERBOSE;
   } else if (this.opt.verbose === false) {
-    this.opt.verbose = util.LOG_LEVEL_INFO;
+    this.opt.logLevel = util.LOG_LEVEL_INFO;
   }
   
   var id = browserWindow ? browserWindow.id : '_no_browser';

--- a/lib/client.js
+++ b/lib/client.js
@@ -15,7 +15,7 @@ var Client = function () {};
 var defaultOpt = {
   port: 30080,
   sendBounds: true,
-  verbose: false
+  verbose: 1
 };
 Client.prototype = new EventEmitter();
 
@@ -24,11 +24,11 @@ Client.prototype.warn = function (msg) {
 };
 
 Client.prototype.info = function (msg) {
-  console.log('[' + new Date().toISOString() + '] [electron-connect] [client: ' + this.id + '] ' + msg);
+  if(this.opt.verbose >= 1) console.log('[' + new Date().toISOString() + '] [electron-connect] [client: ' + this.id + '] ' + msg);
 };
 
 Client.prototype.verbose = function (msg) {
-  if(this.opt.verbose) console.log('[' + new Date().toISOString() + '] [electron-connect] [client: ' + this.id + '] ' + msg);
+  if(this.opt.verbose === 2) console.log('[' + new Date().toISOString() + '] [electron-connect] [client: ' + this.id + '] ' + msg);
 };
 
 Client.prototype.join = function (browserWindow, options, cb) {
@@ -50,6 +50,12 @@ Client.prototype.join = function (browserWindow, options, cb) {
       cb = browserWindow;
     }
     browserWindow = getBrowserWindow();
+  }
+  // handle old boolean verbose values
+  if (this.opt.verbose === true) {
+    this.opt.verbose = 2;
+  } else if (this.opt.verbose === false) {
+    this.opt.verbose = 1;
   }
   var id = browserWindow ? browserWindow.id : '_no_browser';
   this.id = id;

--- a/lib/server.js
+++ b/lib/server.js
@@ -16,6 +16,12 @@ var ProcessManager = function () {
 ProcessManager.prototype = new EventEmitter();
 ProcessManager.prototype.init = function (opt) {
   this.opt = opt;
+  // handle old boolean verbose values
+  if (this.opt.verbose === true) {
+    this.opt.verbose = 2;
+  } else if (this.opt.verbose === false) {
+    this.opt.verbose = 1;
+  }
   this.numClients = 0;
   this.electronState = 'init';
   this.restartCallback = null;
@@ -27,11 +33,11 @@ ProcessManager.prototype.warn= function (msg) {
 };
 
 ProcessManager.prototype.info = function (msg) {
-  console.log('[' + new Date().toISOString() + '] [electron-connect] [server]', msg);
+  if(this.opt.verbose >= 1) console.log('[' + new Date().toISOString() + '] [electron-connect] [server]', msg);
 };
 
 ProcessManager.prototype.verbose = function (msg) {
-  if(this.opt.verbose) console.log('[' + new Date().toISOString() + '] [electron-connect] [server]', msg);
+  if(this.opt.verbose === 2) console.log('[' + new Date().toISOString() + '] [electron-connect] [server]', msg);
 };
 
 ProcessManager.prototype.setStateAndInvokeCallback = function(procState, cb) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -6,6 +6,7 @@ var kill = require('tree-kill');
 var webSocket = require('ws');
 var _ = require('lodash');
 var SocketWrapper = require('./socketWrapper');
+var util = require('./util');
 
 var ProcessManager = function () {
   this.start = this.start.bind(this);
@@ -16,12 +17,14 @@ var ProcessManager = function () {
 ProcessManager.prototype = new EventEmitter();
 ProcessManager.prototype.init = function (opt) {
   this.opt = opt;
+  
   // handle old boolean verbose values
   if (this.opt.verbose === true) {
-    this.opt.verbose = 2;
+    this.opt.verbose = util.LOG_LEVEL_VERBOSE;
   } else if (this.opt.verbose === false) {
-    this.opt.verbose = 1;
+    this.opt.verbose = util.LOG_LEVEL_INFO;
   }
+
   this.numClients = 0;
   this.electronState = 'init';
   this.restartCallback = null;
@@ -33,11 +36,11 @@ ProcessManager.prototype.warn= function (msg) {
 };
 
 ProcessManager.prototype.info = function (msg) {
-  if(this.opt.verbose >= 1) console.log('[' + new Date().toISOString() + '] [electron-connect] [server]', msg);
+  if(this.opt.logLevel >= util.LOG_LEVEL_INFO) console.log('[' + new Date().toISOString() + '] [electron-connect] [server]', msg);
 };
 
 ProcessManager.prototype.verbose = function (msg) {
-  if(this.opt.verbose === 2) console.log('[' + new Date().toISOString() + '] [electron-connect] [server]', msg);
+  if(this.opt.logLevel >= util.LOG_LEVEL_VERBOSE) console.log('[' + new Date().toISOString() + '] [electron-connect] [server]', msg);
 };
 
 ProcessManager.prototype.setStateAndInvokeCallback = function(procState, cb) {
@@ -228,7 +231,7 @@ module.exports = {
       electron: electron,
       path: process.cwd(),
       port: 30080,
-      verbose: 1,
+      logLevel: util.LOG_LEVEL_INFO,
       spawnOpt: {stdio: 'inherit'}
     }, options || {});
     return new ProcessManager().init(opt);

--- a/lib/server.js
+++ b/lib/server.js
@@ -228,7 +228,7 @@ module.exports = {
       electron: electron,
       path: process.cwd(),
       port: 30080,
-      verbose: false,
+      verbose: 1,
       spawnOpt: {stdio: 'inherit'}
     }, options || {});
     return new ProcessManager().init(opt);

--- a/lib/server.js
+++ b/lib/server.js
@@ -20,9 +20,9 @@ ProcessManager.prototype.init = function (opt) {
   
   // handle old boolean verbose values
   if (this.opt.verbose === true) {
-    this.opt.verbose = util.LOG_LEVEL_VERBOSE;
+    this.opt.logLevel = util.LOG_LEVEL_VERBOSE;
   } else if (this.opt.verbose === false) {
-    this.opt.verbose = util.LOG_LEVEL_INFO;
+    this.opt.logLevel = util.LOG_LEVEL_INFO;
   }
 
   this.numClients = 0;

--- a/lib/util.js
+++ b/lib/util.js
@@ -12,5 +12,8 @@ module.exports = {
   getIdFromUrl: function (url) {
     var matched = url.match(/\?window_id=([^&])/);
     return matched && matched[1];
-  }
+  },
+  LOG_LEVEL_WARNING: 0,
+  LOG_LEVEL_INFO: 1,
+  LOG_LEVEL_VERBOSE: 2,
 };


### PR DESCRIPTION
I wanted a way to silence the all but the most important logs, to reduce a bit of the clutter in my command window.

Verbose is now a Number option:
- `0` = warnings
- `1` = warnings + info
- `2` = warnings + info + verbose

Has handling for converting the old boolean property value to the Number value:
- `false` maps to `1`
- `true` maps to `2`