### PR TITLE
Display a better error message when electron is not installed

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -54,6 +54,12 @@ ProcessManager.prototype.spawn = function (args, spawnOpt) {
   // HACK - for now, pass electron option to preload some module (i picked 'process' module).
   args = ["-r process"].concat(args);
   this.electronProc = spawn(this.opt.electron, args.concat([this.opt.path]), spawnOpt);
+
+  if (!this.electronProc.pid) {
+    throw new Error('Failed to spawn an electron process. ' +
+                    'Do you have electron installed either in the project or globally?');
+  }
+
   this.info('started electron process: ' + this.electronProc.pid);
 };
 


### PR DESCRIPTION
If electron is not installed either in the project or globally the error looked like this:

```
[2016-10-23T02:17:40.846Z] [electron-connect] [server] started electron process: undefined
[2016-10-23T02:17:40.846Z] [electron-connect] [server] created and listening on 30080
events.js:160
      throw er; // Unhandled 'error' event
      ^

Error: spawn electron ENOENT
    at exports._errnoException (util.js:1026:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:193:32)
    at onErrorNT (internal/child_process.js:359:16)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
    at Module.runMain (module.js:606:11)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3
```

I didn't have electron installed (stupid me) and spent quite some time looking for problems in my gulp script and other places, and a more descriptive error message would've saved me a handful of minutes.