### PR TITLE
Fixes the args parameter

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -52,8 +52,7 @@ ProcessManager.prototype.setStateAndInvokeCallback = function(procState, cb) {
 
 ProcessManager.prototype.spawn = function (args, spawnOpt) {
   // HACK - for now, pass electron option to preload some module (i picked 'process' module).
-  args = ["-r process"].concat(args);
-  this.electronProc = spawn(this.opt.electron, args.concat([this.opt.path]), spawnOpt);
+  this.electronProc = spawn(this.opt.electron, ["-r process", this.opt.path].concat(args), spawnOpt);
   this.info('started electron process: ' + this.electronProc.pid);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-connect",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Livereload tools for Electron development",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If you try to pass some arguments to `electron` using the `args` parameters doesn't work properly.

```
const electron = require("electron-connect").server.create();
electron.start(["--api", "http://localhost:4444/api"], (procState) => { ... });
```