### PR TITLE
Handling ECONNRESET caused when restarting browser process

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -105,6 +105,9 @@ ProcessManager.prototype.start = function (args, cb) {
         }
       }
     }.bind(this));
+    wrapper.on('error', function (err) {
+      if (err.code !== 'ECONNRESET') { throw err } 
+    }.bind(this));
     this.info('client (window_id: ' + wrapper.id + ') started.');
     this.numClients++;
   }.bind(this));


### PR DESCRIPTION
**Problem:**

My electron-connect server was crashing with `ECONNRESET` every time the browser process was being restarted, this seems to be due to the client process being killed and the socket not being closed correctly.

**Changes proposed:**

* Simply, make the wrapper throw any exception beside `ECONNRESET`